### PR TITLE
[R4R]fix review comments

### DIFF
--- a/contracts/BSCSwapAgentImpl.template
+++ b/contracts/BSCSwapAgentImpl.template
@@ -48,13 +48,10 @@ contract  BSCSwapAgentImpl is Context, Initializable {
 
     modifier notContract() {
         require(!isContract(msg.sender), "contract is not allowed to swap");
-        _;
+        require(msg.sender == tx.origin, "no proxy contract is allowed");
+       _;
     }
 
-    modifier noProxy() {
-        require(msg.sender == tx.origin, "no proxy is allowed");
-        _;
-    }
 
 {% if mock %}
 {% else %}
@@ -124,9 +121,8 @@ contract  BSCSwapAgentImpl is Context, Initializable {
         require(!filledETHTx[ethTxHash], "eth tx filled already");
         address bscTokenAddr = swapMappingETH2BSC[erc20Addr];
         require(bscTokenAddr != address(0x0), "no swap pair for this token");
-
-        ISwap(bscTokenAddr).mintTo(amount, toAddress);
         filledETHTx[ethTxHash] = true;
+        ISwap(bscTokenAddr).mintTo(amount, toAddress);
         emit SwapFilled(bscTokenAddr, ethTxHash, toAddress, amount);
 
         return true;
@@ -134,10 +130,10 @@ contract  BSCSwapAgentImpl is Context, Initializable {
     /**
      * @dev swapBSC2ETH
      */
-    function swapBSC2ETH(address bep20Addr, uint256 amount) payable external notContract noProxy returns (bool) {
+    function swapBSC2ETH(address bep20Addr, uint256 amount) payable external notContract returns (bool) {
         address erc20Addr = swapMappingBSC2ETH[bep20Addr];
         require(erc20Addr != address(0x0), "no swap pair for this token");
-        require(msg.value >= swapFee, "swap fee is not enough");
+        require(msg.value == swapFee, "swap fee not equal");
 
         IERC20(bep20Addr).safeTransferFrom(msg.sender, address(this), amount);
         ISwap(bep20Addr).burn(amount);

--- a/contracts/ETHSwapAgentImpl.sol
+++ b/contracts/ETHSwapAgentImpl.sol
@@ -37,12 +37,8 @@ contract ETHSwapAgentImpl is Context, Initializable {
 
     modifier notContract() {
         require(!isContract(msg.sender), "contract is not allowed to swap");
-        _;
-    }
-
-    modifier noProxy() {
-        require(msg.sender == tx.origin, "no proxy is allowed");
-        _;
+        require(msg.sender == tx.origin, "no proxy contract is allowed");
+       _;
     }
 
     function isContract(address addr) internal view returns (bool) {
@@ -100,16 +96,16 @@ contract ETHSwapAgentImpl is Context, Initializable {
         require(!filledBSCTx[bscTxHash], "bsc tx filled already");
         require(registeredERC20[erc20Addr], "not registered token");
 
-        IERC20(erc20Addr).safeTransfer(toAddress, amount);
         filledBSCTx[bscTxHash] = true;
+        IERC20(erc20Addr).safeTransfer(toAddress, amount);
 
         emit SwapFilled(erc20Addr, bscTxHash, toAddress, amount);
         return true;
     }
 
-    function swapETH2BSC(address erc20Addr, uint256 amount) payable external notContract noProxy returns (bool) {
+    function swapETH2BSC(address erc20Addr, uint256 amount) payable external notContract returns (bool) {
         require(registeredERC20[erc20Addr], "not registered token");
-        require(msg.value >= swapFee, "swap fee is not enough");
+        require(msg.value == swapFee, "swap fee not equal");
 
         IERC20(erc20Addr).safeTransferFrom(msg.sender, address(this), amount);
         if (msg.value != 0) {

--- a/contracts/ETHSwapAgentImpl.template
+++ b/contracts/ETHSwapAgentImpl.template
@@ -44,12 +44,8 @@ contract ETHSwapAgentImpl is Context, Initializable {
 {% endif %}
     modifier notContract() {
         require(!isContract(msg.sender), "contract is not allowed to swap");
-        _;
-    }
-
-    modifier noProxy() {
-        require(msg.sender == tx.origin, "no proxy is allowed");
-        _;
+        require(msg.sender == tx.origin, "no proxy contract is allowed");
+       _;
     }
 
     function isContract(address addr) internal view returns (bool) {
@@ -107,16 +103,16 @@ contract ETHSwapAgentImpl is Context, Initializable {
         require(!filledBSCTx[bscTxHash], "bsc tx filled already");
         require(registeredERC20[erc20Addr], "not registered token");
 
-        IERC20(erc20Addr).safeTransfer(toAddress, amount);
         filledBSCTx[bscTxHash] = true;
+        IERC20(erc20Addr).safeTransfer(toAddress, amount);
 
         emit SwapFilled(erc20Addr, bscTxHash, toAddress, amount);
         return true;
     }
 
-    function swapETH2BSC(address erc20Addr, uint256 amount) payable external notContract noProxy returns (bool) {
+    function swapETH2BSC(address erc20Addr, uint256 amount) payable external notContract returns (bool) {
         require(registeredERC20[erc20Addr], "not registered token");
-        require(msg.value >= swapFee, "swap fee is not enough");
+        require(msg.value == swapFee, "swap fee not equal");
 
         IERC20(erc20Addr).safeTransferFrom(msg.sender, address(this), amount);
         if (msg.value != 0) {

--- a/test/TestSwap.js
+++ b/test/TestSwap.js
@@ -25,8 +25,6 @@ contract('ETHSwapAgent and BSCSwapAgent', (accounts) => {
         assert.equal(isERC20DEFRegistered, false, "wrong register status");
 
         let registerTx = await ethSwap.registerSwapPairToBSC(ERC20ABC.address, {from: accounts[0]});
-        console.log("tx: ", registerTx)
-        console.log("tx: ", registerTx.tx)
         truffleAssert.eventEmitted(registerTx, "SwapPairRegister",(ev) => {
             return ev.erc20Addr === ERC20ABC.address && ev.name.toString() === "ABC token" && ev.symbol.toString() === "ABC" && ev.decimals.toString() === "18";
         });
@@ -35,7 +33,6 @@ contract('ETHSwapAgent and BSCSwapAgent', (accounts) => {
         let createTx = await bscSwap.createSwapPair(registerTx.tx, ERC20ABC.address, "ABC token", "ABC", web3.utils.toBN(18), {from: accounts[0]});
         truffleAssert.eventEmitted(createTx, "SwapPairCreated",(ev) => {
             createdBEP20TokenAddr = ev.bep20Addr;
-            console.log("created bep20 token: ", createdBEP20TokenAddr)
             return ev.ethRegisterTxHash === registerTx.tx && ev.erc20Addr === ERC20ABC.address && ev.symbol.toString() === "ABC" && ev.decimals.toString() === "18";
         });
 
@@ -82,7 +79,7 @@ contract('ETHSwapAgent and BSCSwapAgent', (accounts) => {
             await ethSwap.swapETH2BSC(ERC20ABC.address, "100000", {from: accounts[0]})
             assert.fail();
         } catch (error) {
-            assert.ok(error.toString().includes("swap fee is not enough"))
+            assert.ok(error.toString().includes("swap fee not equal"))
         }
 
         try {
@@ -163,7 +160,6 @@ contract('ETHSwapAgent and BSCSwapAgent', (accounts) => {
             await bscSwap.fillETH2BSCSwap("0x01", ERC20DEF.address, accounts[0], "100000", {from: accounts[0]});
             assert.fail();
         } catch (error) {
-            console.log("xxxx: ", error.toString())
             assert.ok(error.toString().includes("no swap pair for this token"))
         }
     });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -45,7 +45,7 @@ module.exports = {
     development: {
      host: "127.0.0.1",     // Localhost (default: none)
      port: 8545,            // Standard Ethereum port (default: none)
-     network_id: "123",       // Any network (default: none)
+      network_id: "*",       // Any network (default: none)
     },
 
     // Another network with more advanced options...


### PR DESCRIPTION
### Description

### Rationale
EBS-001: Combine notContract and noProxy together
Proxy has to be a smart contract, so it should fail notContract check too.

EBS-002: Change order of state change/external call
e.g.

```
IERC20(erc20Addr).safeTransfer(toAddress, amount);
filledBSCTx[bscTxHash] = true;
```
⇒
```
filledBSCTx[bscTxHash] = true;
IERC20(erc20Addr).safeTransfer(toAddress, amount); 
```

EBS-003: 
check that msg.value == swapFee to prevent user overspending due to typo when sending the tx.


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
