### PR TITLE
[R4R]using fixed sol version

### DIFF
--- a/contracts/bep20/BEP20TokenImplementation.sol
+++ b/contracts/bep20/BEP20TokenImplementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 import "../interfaces/IBEP20.sol";
 import "../interfaces/ISwap.sol";

--- a/contracts/bep20/BEP20UpgradeableProxy.sol
+++ b/contracts/bep20/BEP20UpgradeableProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 import "openzeppelin-solidity/contracts/proxy/TransparentUpgradeableProxy.sol";
 

--- a/contracts/interfaces/IBEP20.sol
+++ b/contracts/interfaces/IBEP20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 interface IBEP20 {
     /**

--- a/contracts/interfaces/IERC20Query.sol
+++ b/contracts/interfaces/IERC20Query.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 interface IERC20Query {
     /**

--- a/contracts/interfaces/IProxyInitialize.sol
+++ b/contracts/interfaces/IProxyInitialize.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 interface IProxyInitialize {
     function initialize(string calldata name, string calldata symbol, uint8 decimals, uint256 amount, bool mintable, address owner) external;

--- a/contracts/interfaces/ISwap.sol
+++ b/contracts/interfaces/ISwap.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 interface ISwap {
     /**


### PR DESCRIPTION
Files on ​BSCSwapAgentImpl​and ​ETHSwapAgentImpl​are using version of​ 0.6.4,​while other files are not anchored to the specific version.

Aligning the versions or give a range of 0.6.4 for compatibility.